### PR TITLE
Don't nag detected friend codes when its in a url

### DIFF
--- a/modules/social.py
+++ b/modules/social.py
@@ -41,7 +41,7 @@ class SocialFeatures(commands.Cog, name='Social Commands'):
             # Profile setup/editor (lenient)
             "profile": re.compile(r'(?:sw)?[ \-\u2014]?(\d{4})[ \-\u2014]?(\d{4})[ \-\u2014]?(\d{4})', re.I),
             # Chat filter, "It appears you've sent a friend code." Requires separators; discards AC designer prefixes and urls
-            "chatFilter": re.compile(r'(?!\s*https?:\/\/[^ "<>\\^`{|}]+)(?!\s*\S*m[ao])(?:(?:^|\s)\S*)(\d{4})[ \-\u2014](\d{4})[ \-\u2014](\d{4})', re.I + re.M)
+            "chatFilter": re.compile(r'(?!\s*https?:\/\/)(?!\s*\S*m[ao][ \-\u2014])(?:(?:^|\s)\S*)(\d{4})[ \-\u2014](\d{4})[ \-\u2014](\d{4})', re.I + re.M)
         }
 
     @commands.group(name='profile', invoke_without_command=True)


### PR DESCRIPTION
# Pull request template
Use this template for all contributions made for the repository.

Please indicate all that apply with a checkmark. To make a check, convert brackets below to `[x]`.

* [ ] **Feature implementation**
* [ ] **Bug fix**
* [x] **Code change/improvement**
* [x] **String change (i.e. grammar/spelling error or an addition)**

***

## Describe what your pull request does
Removes detection of friend codes when they are in a URL.

## Related issues and extra details
This solution introduces a few edge cases compared to before, but these are minimal and not too impactful. Namely:
- ~~Animal crossing designer codes are detected if they are not separated by a newline/whitespace/beginning of message. (eg. `fooma-5555-5555-5555` is detected.)~~ Fixed in f78bb1f
- Animal crossing designer codes must be prefixed by a dash to be filtered. (eg. `ma 5555-5555-5555` and `ma5555-5555-5555` are detected.) 
