### PR TITLE
Limit profile command in some contexts

### DIFF
--- a/modules/social.py
+++ b/modules/social.py
@@ -621,7 +621,7 @@ class SocialFeatures(commands.Cog, name='Social Commands'):
             if cmd_str == 'profile' and (ctx.message.channel.id in [config.commandsChannel, config.voiceTextChannel] or ctx.guild.get_role(config.moderator) in ctx.author.roles):
                 await self._profile.__call__(ctx, None if not ctx.args else ctx.args[0])
             else:
-                return await ctx.send(f'{config.redTick} You are using that command too fast, try again in a few seconds.', delete_after=15)
+                return await ctx.send(f'{config.redTick} That command is being used too often, try again in a few seconds.', delete_after=15)
 
         else:
             await ctx.send(f'{config.redTick} An unknown exception has occured, if this continues to happen contact the developer.', delete_after=15)


### PR DESCRIPTION
- Cooldown profile command to 2/60 sec/channel unless in commands channel or mod.
- Disallow !profile use on self, if not in commands channel, if user has not set up their profile.

# Pull request template
Use this template for all contributions made for the repository.

Please indicate all that apply with a checkmark. To make a check, convert brackets below to `[x]`.

* [x] **Feature implementation**
* [ ] **Bug fix**
* [x] **Code change/improvement**
* [ ] **String change (i.e. grammar/spelling error or an addition)**
