### PR TITLE
refractor errors not in profile to use on_command_error

### DIFF
--- a/modules/moderation.py
+++ b/modules/moderation.py
@@ -622,18 +622,7 @@ class Moderation(commands.Cog, name='Moderation Commands'):
 
         await ctx.send(f'{config.greenTick} removed {_id}: {doc["type"]} against {doc["user"]} by {doc["moderator"]}')
 
-    @_banning.error
-    @_unbanning.error
-    @_kicking.error
-    @_strike.error
-    @_strike_set.error
-    @_muting.error
-    @_unmuting.error
-    @_warning.error
-    @_strike.error
-    @_note.error
-    @_hide_modlog.error
-    async def mod_error(self, ctx, error):
+    async def on_command_error(self, ctx: commands.Context, error: commands.CommandError):
         cmd_str = ctx.command.full_parent_name + ' ' + ctx.command.name if ctx.command.parent else ctx.command.name
         if isinstance(error, commands.MissingRequiredArgument):
             return await ctx.send(

--- a/modules/social.py
+++ b/modules/social.py
@@ -540,9 +540,7 @@ class SocialFeatures(commands.Cog, name='Social Commands'):
             backgrounds.remove('default')
 
             if not backgrounds:
-                await message.channel.send(
-                    'Since you don\'t have any background themes unlocked we\'ll skip this step'
-                )
+                await message.channel.send('Since you don\'t have any background themes unlocked we\'ll skip this step')
                 return True
 
             else:
@@ -554,9 +552,7 @@ class SocialFeatures(commands.Cog, name='Social Commands'):
                     content = response.content.lower().strip()
                     if response.content.lower().strip() == 'reset':
                         db.update_one({'_id': ctx.author.id}, {'$set': {'background': 'default'}})
-                        await message.channel.send(
-                            'I\'ve gone ahead and reset your setting for **profile background**'
-                        )
+                        await message.channel.send('I\'ve gone ahead and reset your setting for **profile background**')
                         return True
 
                     elif content != 'skip':

--- a/modules/social.py
+++ b/modules/social.py
@@ -540,7 +540,9 @@ class SocialFeatures(commands.Cog, name='Social Commands'):
             backgrounds.remove('default')
 
             if not backgrounds:
-                await message.channel.send('Since you don\'t have any background themes unlocked we\'ll skip this step')
+                await message.channel.send(
+                    'Since you don\'t have any background themes unlocked we\'ll skip this step'
+                )
                 return True
 
             else:
@@ -552,7 +554,9 @@ class SocialFeatures(commands.Cog, name='Social Commands'):
                     content = response.content.lower().strip()
                     if response.content.lower().strip() == 'reset':
                         db.update_one({'_id': ctx.author.id}, {'$set': {'background': 'default'}})
-                        await message.channel.send('I\'ve gone ahead and reset your setting for **profile background**')
+                        await message.channel.send(
+                            'I\'ve gone ahead and reset your setting for **profile background**'
+                        )
                         return True
 
                     elif content != 'skip':

--- a/modules/statistics.py
+++ b/modules/statistics.py
@@ -247,12 +247,7 @@ class StatCommands(commands.Cog, name='Statistic Commands'):
     async def _stats_channels(self, ctx):
         return await ctx.send(f'{config.redTick} Channel statistics are not ready for use')
 
-    @_stats.error
-    @_stats_channels.error
-    @_stats_roles.error
-    @_stats_server.error
-    @_stats_users.error
-    async def stat_error(self, ctx, error):
+    async def on_command_error(self, ctx: commands.Context, error: commands.CommandError):
         cmd_str = ctx.command.full_parent_name + ' ' + ctx.command.name if ctx.command.parent else ctx.command.name
         if isinstance(error, commands.MissingRequiredArgument):
             return await ctx.send(

--- a/modules/utility.py
+++ b/modules/utility.py
@@ -903,9 +903,7 @@ class ChatControl(commands.Cog, name='Utility Commands'):
             db.update_one(
                 {'_id': tag['_id']},
                 {
-                    '$push': {
-                        'revisions': {str(int(time.time())): {'content': tag['content'], 'user': ctx.author.id}}
-                    },
+                    '$push': {'revisions': {str(int(time.time())): {'content': tag['content'], 'user': ctx.author.id}}},
                     '$set': {'content': content, 'active': True},
                 },
             )

--- a/modules/utility.py
+++ b/modules/utility.py
@@ -903,7 +903,9 @@ class ChatControl(commands.Cog, name='Utility Commands'):
             db.update_one(
                 {'_id': tag['_id']},
                 {
-                    '$push': {'revisions': {str(int(time.time())): {'content': tag['content'], 'user': ctx.author.id}}},
+                    '$push': {
+                        'revisions': {str(int(time.time())): {'content': tag['content'], 'user': ctx.author.id}}
+                    },
                     '$set': {'content': content, 'active': True},
                 },
             )
@@ -1168,19 +1170,7 @@ class ChatControl(commands.Cog, name='Utility Commands'):
 
         await ctx.send(f'{config.greenTick} {member} has been {statusText.lower()}ed from {mention}')
 
-    @_clean.error
-    @_info.error
-    @_history.error
-    @_roles.error
-    @_roles_set.error
-    @_tag.error
-    @_tag_list.error
-    @_tag_create.error
-    @_tag_delete.error
-    @_tag_setdesc.error
-    @_tag_setimg.error
-    @_tag_source.error
-    async def utility_error(self, ctx, error):
+    async def on_command_error(self, ctx: commands.Context, error: commands.CommandError):
         cmd_str = ctx.command.full_parent_name + ' ' + ctx.command.name if ctx.command.parent else ctx.command.name
         if isinstance(error, commands.MissingRequiredArgument):
             return await ctx.send(


### PR DESCRIPTION
# Pull request template
Use this template for all contributions made for the repository.

Please indicate all that apply with a checkmark. To make a check, convert brackets below to `[x]`.

* [ ] **Feature implementation**
* [ ] **Bug fix**
* [x] **Code change/improvement**
* [ ] **String change (i.e. grammar/spelling error or an addition)**

***

## Describe what your pull request does
except for profile cog, all commands in every cog have a built in error handler - it is more meaning ful and easier to maintain if we used a on_command_error instead of @_cmdmeth.error decorator for each command we add.

## Related issues and extra details
Link to any issues that this PR is related to and include extra info such as pictures, if applicable.
